### PR TITLE
Fix torneos: nombre real y temporizador 

### DIFF
--- a/Backend/AuthPersonalTrackingTorneos/api/src/auth/auth.controller.spec.ts
+++ b/Backend/AuthPersonalTrackingTorneos/api/src/auth/auth.controller.spec.ts
@@ -1,5 +1,6 @@
 import { AuthController } from './auth.controller';
 import { AuthService } from './auth.service';
+import { PersonalTrackingBootstrapService } from '../personal-tracking/bootstrap/personal-tracking-bootstrap.service';
 
 describe('AuthController', () => {
   let controller: AuthController;
@@ -17,6 +18,9 @@ describe('AuthController', () => {
       | 'listUsers'
     >
   >;
+  let bootstrapService: jest.Mocked<
+    Pick<PersonalTrackingBootstrapService, 'ensureInitialized'>
+  >;
 
   beforeEach(() => {
     service = {
@@ -31,7 +35,14 @@ describe('AuthController', () => {
       listUsers: jest.fn(),
     };
 
-    controller = new AuthController(service as unknown as AuthService);
+    bootstrapService = {
+      ensureInitialized: jest.fn(),
+    };
+
+    controller = new AuthController(
+      service as unknown as AuthService,
+      bootstrapService as unknown as PersonalTrackingBootstrapService,
+    );
   });
 
   it('delegates login credentials to the service', async () => {
@@ -138,8 +149,9 @@ describe('AuthController', () => {
     expect(result).toEqual({ ok: true });
   });
 
-  it('returns the authenticated user on verify-token', () => {
+  it('returns the authenticated user on verify-token', async () => {
     const req = {
+      accessToken: 'token-verify',
       robleUser: {
         sub: 'user-1',
         email: 'user@example.com',
@@ -147,10 +159,40 @@ describe('AuthController', () => {
       },
     } as never;
 
-    expect(controller.verifyToken(req)).toEqual({
+    await expect(controller.verifyToken(req)).resolves.toEqual({
       valid: true,
       user: req.robleUser,
     });
+
+    expect(bootstrapService.ensureInitialized).toHaveBeenCalledWith(
+      'token-verify',
+      'user-1',
+      'Alice',
+      'user@example.com',
+    );
+  });
+
+  it('prefers the forwarded display name over the email alias on verify-token', async () => {
+    const req = {
+      accessToken: 'token-verify',
+      headers: {
+        'x-user-display-name': 'Joseph Felipe Venegas Banda',
+      },
+      robleUser: {
+        sub: 'user-2',
+        email: 'venegasbjf@example.com',
+        name: 'venegasbjf',
+      },
+    } as never;
+
+    await controller.verifyToken(req);
+
+    expect(bootstrapService.ensureInitialized).toHaveBeenCalledWith(
+      'token-verify',
+      'user-2',
+      'Joseph Felipe Venegas Banda',
+      'venegasbjf@example.com',
+    );
   });
 
   it('uses the request access token when listing users', async () => {

--- a/Backend/AuthPersonalTrackingTorneos/api/src/auth/auth.controller.ts
+++ b/Backend/AuthPersonalTrackingTorneos/api/src/auth/auth.controller.ts
@@ -28,6 +28,25 @@ export class AuthController {
     private readonly bootstrapService: PersonalTrackingBootstrapService,
   ) {}
 
+  private resolveDisplayNameHint(req: RobleRequest): string {
+    const rawHeader = req?.headers?.['x-user-display-name'];
+    const candidate = Array.isArray(rawHeader) ? rawHeader[0] : rawHeader;
+    if (typeof candidate !== 'string') {
+      return '';
+    }
+
+    const normalized = candidate.trim();
+    if (
+      !normalized ||
+      normalized === 'undefined' ||
+      normalized === 'null'
+    ) {
+      return '';
+    }
+
+    return normalized;
+  }
+
   private resolveBootstrapUser(req: RobleRequest) {
     const payload = ((req && req.robleUser) ? req.robleUser : {}) as Record<string, unknown>;
     const userIdCandidates = [
@@ -47,7 +66,19 @@ export class AuthController {
 
     const email =
       typeof payload.email === 'string' ? payload.email.trim() : '';
-    const nameCandidates = [payload.name, payload.nombre];
+    const hintName = this.resolveDisplayNameHint(req);
+    const combinedTokenName =
+      typeof payload.firstName === 'string' || typeof payload.lastName === 'string'
+        ? `${String(payload.firstName ?? '').trim()} ${String(payload.lastName ?? '').trim()}`.trim()
+        : '';
+    const nameCandidates = [
+      hintName,
+      payload.name,
+      payload.nombre,
+      payload.displayName,
+      payload.fullName,
+      combinedTokenName,
+    ];
     const nameCandidate = nameCandidates.find(
       (candidate) =>
         typeof candidate === 'string' &&

--- a/Backend/AuthPersonalTrackingTorneos/api/src/personal-tracking/bootstrap/personal-tracking-bootstrap.service.ts
+++ b/Backend/AuthPersonalTrackingTorneos/api/src/personal-tracking/bootstrap/personal-tracking-bootstrap.service.ts
@@ -36,16 +36,56 @@ export class PersonalTrackingBootstrapService {
     return normalized;
   }
 
+  private getEmailLocalPart(correo?: string): string {
+    const normalizedEmail = this.normalizeEmail(correo);
+    if (!normalizedEmail || !normalizedEmail.includes('@')) {
+      return '';
+    }
+
+    return normalizedEmail.split('@')[0] || '';
+  }
+
+  private isLikelyOpaqueUserId(value?: string | null): boolean {
+    const normalized = String(value ?? '').trim();
+    if (!normalized) {
+      return false;
+    }
+
+    if (
+      /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(
+        normalized,
+      )
+    ) {
+      return true;
+    }
+
+    return /^[A-Za-z0-9_-]{20,}$/.test(normalized) && !/\s/.test(normalized);
+  }
+
   private shouldHydrateExistingName(
     existingName: string | undefined,
     incomingName: string,
+    correo?: string,
   ): boolean {
     const current = String(existingName ?? '').trim();
     if (!current || current === 'undefined' || current === 'null') {
       return incomingName !== 'Usuario';
     }
 
-    return current === 'Usuario' && incomingName !== 'Usuario';
+    if (current === 'Usuario') {
+      return incomingName !== 'Usuario';
+    }
+
+    const emailLocalPart = this.getEmailLocalPart(correo);
+    if (emailLocalPart && current.toLowerCase() === emailLocalPart.toLowerCase()) {
+      return incomingName !== 'Usuario';
+    }
+
+    if (this.isLikelyOpaqueUserId(current)) {
+      return incomingName !== 'Usuario';
+    }
+
+    return false;
   }
 
   private isInvalidUserId(userId: string): boolean {
@@ -88,6 +128,7 @@ export class PersonalTrackingBootstrapService {
           this.shouldHydrateExistingName(
             existingProfile.nombre,
             normalizedName,
+            existingProfile.correo ?? normalizedEmail,
           )
         ) {
           stage = 'hydrate-existing-profile-name';

--- a/Backend/AuthPersonalTrackingTorneos/api/src/torneos/torneos.service.ts
+++ b/Backend/AuthPersonalTrackingTorneos/api/src/torneos/torneos.service.ts
@@ -795,13 +795,6 @@ export class TorneosService {
     const creatorIds = Array.from(
       new Set(
         torneos
-          .filter(
-            (torneo) =>
-              !this.normalizeDisplayName(
-                torneo.creadorNombre,
-                torneo.creadorId,
-              ),
-          )
           .map((torneo) => this.normalizeUserId(torneo.creadorId))
           .filter(Boolean),
       ),
@@ -819,8 +812,8 @@ export class TorneosService {
     return torneos.map((torneo) => {
       const creatorId = this.normalizeUserId(torneo.creadorId);
       const creatorName =
-        this.normalizeDisplayName(torneo.creadorNombre, creatorId) ||
-        creatorNames.get(creatorId);
+        creatorNames.get(creatorId) ||
+        this.normalizeDisplayName(torneo.creadorNombre, creatorId);
       if (!creatorName) {
         return torneo;
       }
@@ -845,10 +838,6 @@ export class TorneosService {
     const userIds = Array.from(
       new Set(
         rows
-          .filter(
-            (row) =>
-              !this.normalizeDisplayName(row.usuarioNombre, row.usuarioId),
-          )
           .map((row) => this.normalizeUserId(row.usuarioId))
           .filter(Boolean),
       ),
@@ -863,8 +852,8 @@ export class TorneosService {
     return rows.map((row) => {
       const userId = this.normalizeUserId(row.usuarioId);
       const userName =
-        this.normalizeDisplayName(row.usuarioNombre, userId) ||
-        userNames.get(userId);
+        userNames.get(userId) ||
+        this.normalizeDisplayName(row.usuarioNombre, userId);
       if (!userName) {
         return row;
       }

--- a/Frontend/Principal/src/context/AuthContext.jsx
+++ b/Frontend/Principal/src/context/AuthContext.jsx
@@ -52,7 +52,10 @@ async function hydrateSession(session) {
     throw new Error('Session without access token')
   }
 
-  const verification = await apiClient.verifyToken(accessToken)
+  const displayNameHint = String(session?.user?.name || '').trim()
+  const verification = await apiClient.verifyToken(accessToken, {
+    headers: displayNameHint ? { 'X-User-Display-Name': displayNameHint } : undefined,
+  })
   return buildUnifiedSession(session, verification?.user || {})
 }
 

--- a/Frontend/Principal/src/hooks/useTournamentSudokuGame.js
+++ b/Frontend/Principal/src/hooks/useTournamentSudokuGame.js
@@ -14,7 +14,17 @@ import {
   isBoardSolved,
 } from '../lib/sudoku.js'
 
+function normalizeElapsedSeconds(value) {
+  const normalized = Math.trunc(Number(value))
+  return Number.isFinite(normalized) && normalized >= 0 ? normalized : 0
+}
+
 function parseTournamentSessionDate(value) {
+  if (typeof value === 'number') {
+    if (!Number.isFinite(value) || value <= 0) return 0
+    return value >= 1e12 ? value : value * 1000
+  }
+
   if (value instanceof Date) {
     const timestamp = value.getTime()
     return Number.isFinite(timestamp) ? timestamp : 0
@@ -23,14 +33,48 @@ function parseTournamentSessionDate(value) {
   const normalized = String(value || '').trim()
   if (!normalized) return 0
 
+  const aspNetMatch = normalized.match(/^\/Date\((\d+)\)\/$/)
+  if (aspNetMatch) {
+    const timestamp = Number(aspNetMatch[1])
+    return Number.isFinite(timestamp) ? timestamp : 0
+  }
+
+  if (/^\d+$/.test(normalized)) {
+    const timestamp = Number(normalized)
+    if (!Number.isFinite(timestamp) || timestamp <= 0) return 0
+    return timestamp >= 1e12 ? timestamp : timestamp * 1000
+  }
+
   const withTimeSeparator = normalized.includes(' ') ? normalized.replace(' ', 'T') : normalized
-  const hasExplicitTimezone = /(?:[zZ]|[+-]\d{2}:\d{2})$/.test(withTimeSeparator)
+  const withExpandedTimezone = withTimeSeparator.replace(/([+-]\d{2})(\d{2})$/, '$1:$2')
+  const trimmedFractions = withExpandedTimezone.replace(/\.(\d{3})\d+/, '.$1')
+  const hasExplicitTimezone = /(?:[zZ]|[+-]\d{2}:\d{2})$/.test(trimmedFractions)
   const needsTimezone =
     !hasExplicitTimezone &&
-    /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}(?::\d{2}(?:\.\d+)?)?$/.test(withTimeSeparator)
+    /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}(?::\d{2}(?:\.\d+)?)?$/.test(trimmedFractions)
 
-  const timestamp = Date.parse(needsTimezone ? `${withTimeSeparator}-05:00` : withTimeSeparator)
+  const timestamp = Date.parse(needsTimezone ? `${trimmedFractions}-05:00` : trimmedFractions)
   return Number.isFinite(timestamp) ? timestamp : 0
+}
+
+function getElapsedSecondsFromSessionStart(session, referenceMs = Date.now()) {
+  const startedAtMs = parseTournamentSessionDate(session?.fechaInicio)
+  if (!startedAtMs) return null
+
+  return normalizeElapsedSeconds(Math.floor((referenceMs - startedAtMs) / 1000))
+}
+
+function getElapsedSecondsFromSnapshot(snapshot, referenceMs = Date.now()) {
+  if (!snapshot || typeof snapshot !== 'object') return null
+
+  const baseElapsedSeconds = normalizeElapsedSeconds(snapshot.elapsedSeconds)
+  const savedAtMs = Number(snapshot.savedAtMs)
+  if (!Number.isFinite(savedAtMs) || savedAtMs <= 0) {
+    return baseElapsedSeconds
+  }
+
+  const extraElapsedSeconds = normalizeElapsedSeconds(Math.floor((referenceMs - savedAtMs) / 1000))
+  return baseElapsedSeconds + extraElapsedSeconds
 }
 
 function noteViolatesCurrentBoard(board, row, col, num) {
@@ -183,7 +227,7 @@ export function useTournamentSudokuGame({ tournamentId, accessToken }) {
   const [game, setGame] = useState(null)
   const [errorCount, setErrorCount] = useState(0)
   const [completedOutcome, setCompletedOutcome] = useState(null)
-  const [nowMs, setNowMs] = useState(() => Date.now())
+  const [elapsedSeconds, setElapsedSeconds] = useState(0)
   const [submissionRequested, setSubmissionRequested] = useState(false)
   const [seriesBoards, setSeriesBoards] = useState([])
   const [currentBoardIndex, setCurrentBoardIndex] = useState(0)
@@ -222,8 +266,6 @@ export function useTournamentSudokuGame({ tournamentId, accessToken }) {
   }, [currentBoardIndex])
 
   const difficulty = game ? getDifficultyByKey(game.difficultyKey) : getDifficultyByKey('medio')
-  const startedAtMs = parseTournamentSessionDate(session?.fechaInicio)
-  const elapsedSeconds = startedAtMs ? Math.max(0, Math.floor((nowMs - startedAtMs) / 1000)) : 0
   const timeLimitSeconds = Number.isFinite(Number(game?.timeLimitSeconds)) ? Number(game.timeLimitSeconds) : null
   const timeRemainingSeconds =
     timeLimitSeconds === null ? null : Math.max(0, timeLimitSeconds - elapsedSeconds)
@@ -320,6 +362,10 @@ export function useTournamentSudokuGame({ tournamentId, accessToken }) {
       const restoredErrorCount = Math.max(0, Number(snapshot?.errorCount || 0))
       const restoredNoteMode = snapshot?.noteMode === true
       const restoredHighlightEnabled = snapshot?.highlightEnabled !== false
+      const restoredElapsedSeconds = Math.max(
+        getElapsedSecondsFromSessionStart(nextSession) ?? 0,
+        getElapsedSecondsFromSnapshot(snapshot) ?? 0,
+      )
 
       setTournament(nextTournament)
       setSession(nextSession)
@@ -327,7 +373,7 @@ export function useTournamentSudokuGame({ tournamentId, accessToken }) {
       setSeriesBoards(restoredSeriesBoards)
       setCurrentBoardIndex(resolvedCurrentBoardIndex)
       setErrorCount(restoredErrorCount)
-      setNowMs(Date.now())
+      setElapsedSeconds(restoredElapsedSeconds)
       hydrateSeriesBoard(restoredSeriesBoards, resolvedCurrentBoardIndex, {
         noteMode: restoredNoteMode,
         highlightEnabled: restoredHighlightEnabled,
@@ -383,6 +429,8 @@ export function useTournamentSudokuGame({ tournamentId, accessToken }) {
         solved: entry.solved,
       })),
       errorCount,
+      elapsedSeconds,
+      savedAtMs: Date.now(),
       noteMode,
       highlightEnabled,
     }
@@ -391,6 +439,7 @@ export function useTournamentSudokuGame({ tournamentId, accessToken }) {
   }, [
     board,
     currentBoardIndex,
+    elapsedSeconds,
     errorCount,
     highlightEnabled,
     isCompleted,
@@ -401,14 +450,14 @@ export function useTournamentSudokuGame({ tournamentId, accessToken }) {
   ])
 
   useEffect(() => {
-    if (!session || isCompleted) return undefined
+    if (!session || isCompleted || submissionRequested) return undefined
 
     const interval = window.setInterval(() => {
-      setNowMs(Date.now())
+      setElapsedSeconds((current) => current + 1)
     }, 1000)
 
     return () => window.clearInterval(interval)
-  }, [isCompleted, session])
+  }, [isCompleted, session, submissionRequested])
 
   async function finalizeGame(providedBoards) {
     if (!accessToken || !tournamentId || !session?._id || finishInFlightRef.current) {
@@ -435,6 +484,9 @@ export function useTournamentSudokuGame({ tournamentId, accessToken }) {
 
       setCompletedOutcome(payload)
       setSession(payload?.session || session)
+      if (Number.isFinite(Number(payload?.elapsedSeconds))) {
+        setElapsedSeconds(normalizeElapsedSeconds(payload.elapsedSeconds))
+      }
       clearSnapshot(session._id)
       setPageStatus(
         payload?.outcome === 'EXPIRADA'

--- a/Frontend/Principal/src/pages/TournamentManagePage.test.jsx
+++ b/Frontend/Principal/src/pages/TournamentManagePage.test.jsx
@@ -63,7 +63,9 @@ describe('TournamentManagePage', () => {
   it('asks guests to sign in when they open a private invite link', async () => {
     renderPage('/torneos/torneo-1?codigo=ABC123')
 
-    expect(screen.getByText('Esta invitacion privada requiere sesion')).toBeInTheDocument()
+    expect(
+      screen.getByRole('heading', { name: /esta invitaci.n privada requiere sesi.n/i }),
+    ).toBeInTheDocument()
     expect(mockApiClient.getPublicTournament).not.toHaveBeenCalled()
   })
 

--- a/Frontend/Principal/src/pages/TournamentsPage.test.jsx
+++ b/Frontend/Principal/src/pages/TournamentsPage.test.jsx
@@ -61,7 +61,9 @@ describe('TournamentsPage', () => {
 
     await waitFor(() => {
       expect(
-        screen.getByText('Debes iniciar sesion para ver los torneos en este entorno'),
+        screen.getByRole('heading', {
+          name: /debes iniciar sesi.n para ver los torneos en este entorno/i,
+        }),
       ).toBeInTheDocument()
     })
 

--- a/Frontend/Principal/src/services/apiClient.js
+++ b/Frontend/Principal/src/services/apiClient.js
@@ -99,9 +99,14 @@ async function performRequest(path, options = {}, tokenOverride = null) {
   const baseUrl = options.baseUrl || 'auth'
   const token = tokenOverride ?? resolveRequestToken(baseUrl, options.token)
   const signal = options.signal
+  const extraHeaders =
+    options.headers && typeof options.headers === 'object' && !Array.isArray(options.headers)
+      ? options.headers
+      : {}
 
   const headers = {
     Accept: 'application/json',
+    ...extraHeaders,
   }
 
   if (body !== undefined) {
@@ -288,11 +293,12 @@ export const apiClient = {
     })
   },
 
-  verifyToken(accessToken) {
+  verifyToken(accessToken, options = {}) {
     return request('auth/verify-token', {
       method: 'GET',
       baseUrl: 'auth',
       token: accessToken,
+      headers: options.headers,
     })
   },
 


### PR DESCRIPTION
Para el nombre: se hizo que torneos use el nombre real del perfil/sesión del usuario en vez de tomar el alias del correo o el userId.

Para el temporizador: se cambió para que cuente localmente segundo a segundo, guarde el avance y al salir y volver retome donde iba en vez de reiniciarse.