### PR TITLE
HotFix: Update ELO ranking thresholds in ProfilePage

### DIFF
--- a/Frontend/Principal/src/pages/ProfilePage.jsx
+++ b/Frontend/Principal/src/pages/ProfilePage.jsx
@@ -212,15 +212,19 @@ function ProfilePage() {
         const elo = Number(stats.elo ?? 0)
         const partidasJugadas = Number(stats.partidasJugadas ?? 0)
         const liga =
-          elo >= 301 && elo <= 400
-            ? 'Platino'
-            : elo >= 201 && elo <= 300
-              ? 'Oro'
-              : elo >= 101 && elo <= 200
-                ? 'Plata'
-                : elo >= 0 && elo <= 100
-                  ? 'Bronce'
-                  : '-'
+          elo >= 2501
+            ? 'Maestro'
+            : elo >= 2001
+              ? 'Diamante'
+              : elo >= 1501
+                ? 'Platino'
+                : elo >= 1001
+                  ? 'Oro'
+                  : elo >= 501
+                    ? 'Plata'
+                    : elo >= 0
+                      ? 'Bronce'
+                      : '-'
 
         const frame = getFrameByElo(elo)
         const localUnlocked = new Set(getUnlockedKeysByRules(partidasJugadas, elo))


### PR DESCRIPTION
Se soluciona problema de visualización por mala delimitación de ligas.
Se agregan divisiones de Diamante y Maestro además de ampliar los intervalos a 100 puntos.